### PR TITLE
fix: Allow to share one toolbar with multiple tiptap instances.

### DIFF
--- a/src/extensions/embed.js
+++ b/src/extensions/embed.js
@@ -3,6 +3,7 @@ import { focus_handler } from "../focus-handler";
 import log from "../tiptap";
 import { Node, mergeAttributes } from "@tiptap/core";
 import { Plugin } from "prosemirror-state";
+import dom from "@patternslib/patternslib/src/core/dom";
 import events from "@patternslib/patternslib/src/core/events";
 
 let panel_observer;
@@ -104,7 +105,15 @@ function embed_panel({ app }) {
 
 export function init({ app, button }) {
     // Initialize modal after it has injected.
-    button.addEventListener("pat-modal-ready", () => embed_panel({ app: app }));
+    button.addEventListener("pat-modal-ready", () => {
+        if (dom.get_data(app.toolbar_el, "tiptap-instance", null) !== app) {
+            // If this pat-tiptap instance is not the one which was last
+            // focused, just return and do nothing.
+            // This might be due to one toolbar shared by multiple editors.
+            return;
+        }
+        embed_panel({ app: app });
+    });
 }
 
 export const factory = () => {

--- a/src/extensions/image-figure.js
+++ b/src/extensions/image-figure.js
@@ -2,6 +2,7 @@ import { focus_handler } from "../focus-handler";
 import log from "../tiptap";
 import { Node, mergeAttributes } from "@tiptap/core";
 import { Plugin } from "prosemirror-state";
+import dom from "@patternslib/patternslib/src/core/dom";
 import events from "@patternslib/patternslib/src/core/events";
 
 let panel_observer;
@@ -120,7 +121,15 @@ function image_panel({ app }) {
 
 export function init({ app, button }) {
     // Initialize modal after it has injected.
-    button.addEventListener("pat-modal-ready", () => image_panel({ app: app }));
+    button.addEventListener("pat-modal-ready", () => {
+        if (dom.get_data(app.toolbar_el, "tiptap-instance", null) !== app) {
+            // If this pat-tiptap instance is not the one which was last
+            // focused, just return and do nothing.
+            // This might be due to one toolbar shared by multiple editors.
+            return;
+        }
+        image_panel({ app: app });
+    });
 }
 
 export const factory = () => {

--- a/src/extensions/link.js
+++ b/src/extensions/link.js
@@ -2,6 +2,7 @@ import { context_menu, context_menu_close } from "../context_menu";
 import { focus_handler } from "../focus-handler";
 import log from "../tiptap";
 import LinkExtension from "@tiptap/extension-link";
+import dom from "@patternslib/patternslib/src/core/dom";
 import events from "@patternslib/patternslib/src/core/events";
 import utils from "@patternslib/patternslib/src/core/utils";
 
@@ -189,7 +190,15 @@ async function link_panel({ app }) {
 
 export function init({ app, button }) {
     // Initialize modal after it has injected.
-    button.addEventListener("pat-modal-ready", () => link_panel({ app: app }));
+    button.addEventListener("pat-modal-ready", () => {
+        if (dom.get_data(app.toolbar_el, "tiptap-instance", null) !== app) {
+            // If this pat-tiptap instance is not the one which was last
+            // focused, just return and do nothing.
+            // This might be due to one toolbar shared by multiple editors.
+            return;
+        }
+        link_panel({ app: app });
+    });
 
     app.editor.on("selectionUpdate", async () => {
         app.editor.isActive("link")

--- a/src/extensions/source.js
+++ b/src/extensions/source.js
@@ -1,5 +1,6 @@
 import { focus_handler } from "../focus-handler";
 import log from "../tiptap";
+import dom from "@patternslib/patternslib/src/core/dom";
 import events from "@patternslib/patternslib/src/core/events";
 
 let panel_observer;
@@ -63,5 +64,13 @@ function source_panel({ app }) {
 
 export function init({ app, button }) {
     // Initialize modal after it has injected.
-    button.addEventListener("pat-modal-ready", () => source_panel({ app: app }));
+    button.addEventListener("pat-modal-ready", () => {
+        if (dom.get_data(app.toolbar_el, "tiptap-instance", null) !== app) {
+            // If this pat-tiptap instance is not the one which was last
+            // focused, just return and do nothing.
+            // This might be due to one toolbar shared by multiple editors.
+            return;
+        }
+        source_panel({ app: app });
+    });
 }

--- a/src/index-many-single-toolbar.html
+++ b/src/index-many-single-toolbar.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>tiptap demo</title>
+    <script src="/bundle.min.js" type="text/javascript" charset="utf-8"></script>
+    <style type="text/css">
+      .tiptap-editor__content {
+        border: 1px solid black;
+        padding: 1em;
+      }
+      .ProseMirror:focus {
+        outline: none;
+      }
+      .active {
+        background-color: green;
+      }
+      table, td, th {
+        border: 1px solid black;
+      }
+      th {
+        background-color: grey;
+        font-weight: bold;
+      }
+
+      /* Placeholder (at the top) */
+      .ProseMirror p.is-editor-empty:first-child::before {
+        content: attr(data-placeholder);
+        float: left;
+        color: #ced4da;
+        pointer-events: none;
+        height: 0;
+      }
+
+      .tooltip-container a,
+      .tooltip-container a:visited {
+        color: white;
+      }
+    </style>
+  </head>
+  <body>
+
+    <h1>TipTap examples</h1>
+
+    <div id="tiptap-toolbar">
+      <button type="button" class="button-heading-level-1">Header level 1</button>
+      <button type="button" class="button-heading-level-2">Header level 2</button>
+      <button type="button" class="button-heading-level-3">Header level 3</button>
+      <button type="button" class="button-paragraph">Normal</button>
+      <button type="button" class="button-bold">Bold</button>
+      <button type="button" class="button-italic">Italic</button>
+      <button type="button" class="button-strike">Strike</button>
+      <button type="button" class="button-unordered-list">Bullet list</button>
+      <button type="button" class="button-ordered-list">Ordered list</button>
+      <button type="button" class="button-undo">Undo</button>
+      <button type="button" class="button-redo">Redo</button>
+      <a class="button-link pat-modal" href="#modal-link">Link</a>
+    </div>
+
+
+    <section>
+      <h2>TipTap -1</h2>
+      <textarea
+          class="pat-tiptap pat-autofocus"
+          data-pat-tiptap="
+            toolbar-external: #tiptap-toolbar;
+            link-panel: #pat-modal .link-panel;
+            link-menu: #context-menu-link"
+          placeholder="Your poem goes here...">
+      </textarea>
+    </section>
+
+    <section>
+      <h2>TipTap -2</h2>
+      <textarea
+          class="pat-tiptap pat-autofocus"
+          data-pat-tiptap="
+            toolbar-external: #tiptap-toolbar;
+            link-panel: #pat-modal .link-panel;
+            link-menu: #context-menu-link"
+          placeholder="Your poem goes here...">
+      </textarea>
+    </section>
+
+    <section>
+      <h2>TipTap -3</h2>
+      <textarea
+          class="pat-tiptap pat-autofocus"
+          data-pat-tiptap="
+            toolbar-external: #tiptap-toolbar;
+            link-panel: #pat-modal .link-panel;
+            link-menu: #context-menu-link"
+          placeholder="Your poem goes here...">
+      </textarea>
+    </section>
+
+    <section>
+      <h2>TipTap -4</h2>
+      <textarea
+          class="pat-tiptap pat-autofocus"
+          data-pat-tiptap="
+            toolbar-external: #tiptap-toolbar;
+            link-panel: #pat-modal .link-panel;
+            link-menu: #context-menu-link"
+          placeholder="Your poem goes here...">
+      </textarea>
+    </section>
+
+    <section>
+      <h2>TipTap -5</h2>
+      <textarea
+          class="pat-tiptap pat-autofocus"
+          data-pat-tiptap="
+            toolbar-external: #tiptap-toolbar;
+            link-panel: #pat-modal .link-panel;
+            link-menu: #context-menu-link"
+          placeholder="Your poem goes here...">
+      </textarea>
+    </section>
+
+    <template id="modal-link">
+        <h1>Add / Edit Link</h1>
+        <form class="link-panel">
+          <label>
+            Link URL:
+            <input type="text" name="tiptap-href"/>
+          </label>
+          <label>
+            Link Text:
+            <input type="text" name="tiptap-text"/>
+          </label>
+          <label>
+            Open in new window:
+            <input type="checkbox" name="tiptap-target" value="_blank" />
+          </label>
+          <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+          <button class="close-panel" type="button" name="tiptap-remove">remove link</button>
+        </form>
+    </template>
+
+    <template id="context-menu-link">
+      <ul class="tiptap-link-context-menu">
+        <li>
+          <a
+            class="close-panel tiptap-open-new-link"
+            target="_blank"
+            href="">Visit linked web page</a>
+        </li>
+        <li>
+          <button
+            type="button"
+            class="close-panel tiptap-edit-link">Edit link</button>
+        </li>
+        <li>
+          <button
+            type="button"
+            class="close-panel tiptap-unlink">Unlink</button>
+        </li>
+      </ul>
+    </template>
+
+  </body>
+</html>

--- a/src/tiptap.js
+++ b/src/tiptap.js
@@ -1,6 +1,7 @@
 import Base from "@patternslib/patternslib/src/core/base";
 import Parser from "@patternslib/patternslib/src/core/parser";
 import Registry from "@patternslib/patternslib/src/core/registry";
+import dom from "@patternslib/patternslib/src/core/dom";
 import events from "@patternslib/patternslib/src/core/events";
 import logging from "@patternslib/patternslib/src/core/logging";
 import utils from "@patternslib/patternslib/src/core/utils";
@@ -151,6 +152,10 @@ export default Base.extend({
                 // Note: ``this`` is the pattern instance.
                 utils.timeout(1); // short timeout to ensure focus class is set even if tiptap_blur_handler is called concurrently.
                 this.toolbar_el?.classList.add("tiptap-focus");
+
+                // Set the current focused pat-tiptap instance on the toolbar element.
+                this.toolbar_el &&
+                    dom.set_data(this.toolbar_el, "tiptap-instance", this);
             },
             onBlur: () => {
                 // Note: ``this`` is the pattern instance.

--- a/src/tiptap.test.js
+++ b/src/tiptap.test.js
@@ -99,6 +99,9 @@ describe("pat-tiptap", () => {
         new Pattern(document.querySelectorAll(".pat-tiptap")[1]);
         await utils.timeout(1);
 
+        const containers = document.querySelectorAll(".tiptap-container");
+
+        containers[0].querySelector("[contenteditable]").focus(); // Set focus to bypass toolbar check
         document
             .querySelector("#tiptap-external-toolbar-1 .button-link")
             .dispatchEvent(new Event("pat-modal-ready"));
@@ -109,6 +112,7 @@ describe("pat-tiptap", () => {
         document.querySelector("#link-panel [name=tiptap-confirm]").dispatchEvent(new Event("click")); // prettier-ignore
         await utils.timeout(1);
 
+        containers[1].querySelector("[contenteditable]").focus(); // Set focus to bypass toolbar check
         document
             .querySelector("#tiptap-external-toolbar-2 .button-link")
             .dispatchEvent(new Event("pat-modal-ready"));
@@ -118,8 +122,6 @@ describe("pat-tiptap", () => {
         document.querySelector("#link-panel [name=tiptap-text]").value = "Link text 2"; // prettier-ignore
         document.querySelector("#link-panel [name=tiptap-confirm]").dispatchEvent(new Event("click")); // prettier-ignore
         await utils.timeout(1);
-
-        const containers = document.querySelectorAll(".tiptap-container");
 
         const anchor1 = containers[0].querySelector("a");
         expect(anchor1).toBeTruthy();
@@ -310,6 +312,8 @@ describe("pat-tiptap", () => {
         new Pattern(document.querySelector(".pat-tiptap"));
         await utils.timeout(1);
 
+        document.querySelector(".tiptap-container [contenteditable]").focus(); // Set focus to bypass toolbar check
+
         document
             .querySelector("#tiptap-external-toolbar .button-link")
             .dispatchEvent(new Event("pat-modal-ready"));
@@ -349,6 +353,8 @@ describe("pat-tiptap", () => {
 
         new Pattern(document.querySelector(".pat-tiptap"));
         await utils.timeout(1);
+
+        document.querySelector(".tiptap-container [contenteditable]").focus(); // Set focus to bypass toolbar check
 
         document
             .querySelector("#tiptap-external-toolbar .button-image")
@@ -396,6 +402,8 @@ describe("pat-tiptap", () => {
         new Pattern(document.querySelector(".pat-tiptap"));
         await utils.timeout(1);
 
+        document.querySelector(".tiptap-container [contenteditable]").focus(); // Set focus to bypass toolbar check
+
         document
             .querySelector("#tiptap-external-toolbar .button-image")
             .dispatchEvent(new Event("pat-modal-ready"));
@@ -434,6 +442,8 @@ describe("pat-tiptap", () => {
 
         new Pattern(document.querySelector(".pat-tiptap"));
         await utils.timeout(1);
+
+        document.querySelector(".tiptap-container [contenteditable]").focus(); // Set focus to bypass toolbar check
 
         document
             .querySelector("#tiptap-external-toolbar .button-image")
@@ -507,6 +517,8 @@ describe("pat-tiptap", () => {
         new Pattern(document.querySelector(".pat-tiptap"));
         await utils.timeout(1);
 
+        document.querySelector(".tiptap-container [contenteditable]").focus(); // Set focus to bypass toolbar check
+
         document
             .querySelector("#tiptap-external-toolbar .button-embed")
             .dispatchEvent(new Event("pat-modal-ready"));
@@ -549,6 +561,8 @@ describe("pat-tiptap", () => {
         new Pattern(document.querySelector(".pat-tiptap"));
         await utils.timeout(1);
 
+        document.querySelector(".tiptap-container [contenteditable]").focus(); // Set focus to bypass toolbar check
+
         document
             .querySelector("#tiptap-external-toolbar .button-embed")
             .dispatchEvent(new Event("pat-modal-ready"));
@@ -587,6 +601,8 @@ describe("pat-tiptap", () => {
 
         new Pattern(document.querySelector(".pat-tiptap"));
         await utils.timeout(1);
+
+        document.querySelector(".tiptap-container [contenteditable]").focus(); // Set focus to bypass toolbar check
 
         document
             .querySelector("#tiptap-external-toolbar .button-embed")
@@ -629,6 +645,8 @@ describe("pat-tiptap", () => {
 
         new Pattern(document.querySelector(".pat-tiptap"));
         await utils.timeout(1);
+
+        document.querySelector(".tiptap-container [contenteditable]").focus(); // Set focus to bypass toolbar check
 
         document
             .querySelector("#tiptap-external-toolbar .button-embed")

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -1,3 +1,5 @@
+import dom from "@patternslib/patternslib/src/core/dom";
+
 export function init_pre({ app }) {
     // pre-initialization step:
     // Search for available toolbar buttons.
@@ -195,6 +197,13 @@ export async function init_post({ app }) {
             return;
         }
         btn.addEventListener("click", () => {
+            if (dom.get_data(app.toolbar_el, "tiptap-instance", null) !== app) {
+                // If this pat-tiptap instance is not the one which was last
+                // focused, just return and do nothing.
+                // This might be due to one toolbar shared by multiple editors.
+                return;
+            }
+
             app.editor
                 .chain()
                 .focus()
@@ -254,6 +263,12 @@ export async function init_post({ app }) {
 
     if (tb.table_merge_cells) {
         tb.table_merge_cells.addEventListener("click", () => {
+            if (dom.get_data(app.toolbar_el, "tiptap-instance", null) !== app) {
+                // If this pat-tiptap instance is not the one which was last
+                // focused, just return and do nothing.
+                // This might be due to one toolbar shared by multiple editors.
+                return;
+            }
             app.editor.chain().focus().mergeOrSplit().run();
             app.editor.emit("selectionUpdate");
         });


### PR DESCRIPTION
Fix an issue with a toolbar which is shared among multiple editor
instances would invoke the command on each instance.
Now you have to focus at least once the editor so that the toolbar will
issue a command on it.
When clicking a toolbar button, the last focused texteditor instance is
used to issue to command on.
To make sure that the toolbar will always invoke an action even without
first clicking into a tiptap contenteditable area use pat-autofocus.