### PR TITLE
feat: Late initialization.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,10 +1701,10 @@
     whybundled "^2.0.0"
     yarn "^1.22.19"
 
-"@patternslib/patternslib@*":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@patternslib/patternslib/-/patternslib-8.1.0.tgz#165b07e8d53298ba98f248223d360d216b27b885"
-  integrity sha512-5j5l/JG2N6oGXhBq34jLRTpW+DjW0CijsBwDatIKloxI9o+V0XawQ2Rc9h3qFvXcryXXDxgcqVn0YXdS3l28uQ==
+"@patternslib/patternslib@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@patternslib/patternslib/-/patternslib-9.0.0.tgz#0684c92627bb1578b7178bd9f92f1d226e59bffd"
+  integrity sha512-0nrvhl+8EN5hcjxQaNohBowzDVol5m1ZG+4amYMXPBjE07/6l+gtQCcYn9arPgsxVJqdYxN9wg5LTirMhR/n3w==
   dependencies:
     "@fullcalendar/adaptive" "^5.11.0"
     "@fullcalendar/core" "^5.11.0"
@@ -1717,17 +1717,17 @@
     "@stomp/stompjs" "^6.1.2"
     google-code-prettify "^1.0.5"
     imagesloaded "^4.1.4"
-    intersection-observer "^0.12.0"
+    intersection-observer "^0.12.2"
     jquery "^3.6.0"
     jquery-jcrop "^0.9.13"
     luxon "^2.3.2"
     masonry-layout "^4.2.2"
-    moment "^2.29.3"
+    moment "^2.29.4"
     moment-timezone "^0.5.34"
     photoswipe "^4.1.3"
     pikaday "^1.8.0"
     promise-polyfill "^8.2.3"
-    screenfull "^6.0.1"
+    screenfull "^6.0.2"
     select2 "^3.5.1"
     showdown "^2.1.0"
     showdown-prettify "^1.3.0"
@@ -5233,7 +5233,7 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-intersection-observer@^0.12.0:
+intersection-observer@^0.12.2:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.2.tgz#4a45349cc0cd91916682b1f44c28d7ec737dc375"
   integrity sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==
@@ -6504,7 +6504,7 @@ moment-timezone@^0.5.34:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.29.3:
+"moment@>= 2.9.0", moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -7820,7 +7820,7 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
 
-screenfull@^6.0.1:
+screenfull@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-6.0.2.tgz#3dbe4b8c4f8f49fb8e33caa8f69d0bca730ab238"
   integrity sha512-AQdy8s4WhNvUZ6P8F6PB21tSPIYKniic+Ogx0AacBMjKP1GUHN2E9URxQHtCusiwxudnCKkdy4GrHXPPJSkCCw==


### PR DESCRIPTION
Add ``lazy`` argument (default: ``false``) to initialize tiptap only when the text container gets focus.
This is done via an intermediate container which will be replaced when tiptap has finished it's initialization.

This avoids initializing lots of tiptap instances when many text areas are shown, where most of the time none or only a few are likely to be used.
A typical use case is to show a lot of comment boxes with tiptap mentioning functionality.