### PR TITLE
feat: Better handle submits in link, image, embed and source panels.

### DIFF
--- a/src/documentation.md
+++ b/src/documentation.md
@@ -124,7 +124,7 @@ This is the DOM structure with the overlay:
           Open in new window:
           <input type="checkbox" name="tiptap-target" value="_blank" />
         </label>
-        <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+        <button class="close-panel" type="submit" name="tiptap-confirm">submit</button>
         <button class="close-panel" type="button" name="tiptap-remove">remove link</button>
       </form>
     </div>
@@ -148,6 +148,13 @@ This is the related ``pat-tiptap`` config:
         link-panel: .link-panel;
     "
 
+---
+**Note**
+
+When using buttons with type ``submit`` for ``.tiptap-confirm`` this would become the default action and the changes made in the form would be confirmed and taken over to the text editor.
+A real submit to the server and a full request/response cycle is automatically prevented.
+
+---
 
 #### Adding a link context menu
 
@@ -224,7 +231,7 @@ This is the DOM structure with the overlay:
           Caption:
           <textarea name="tiptap-caption"></textarea>
         </label>
-        <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+        <button class="close-panel" type="submit" name="tiptap-confirm">submit</button>
       </form>
     </div>
 
@@ -241,7 +248,8 @@ You also need to configure ``pat-tiptap`` with the ``image-panel`` option which 
 pat-tiptap uses a ``MutationObserver`` to check for changes in the overlay's DOM structure and re-initializes the functionality once the DOM structure changes.
 This way, you can use ``pat-inject``, ``pat-tabs`` or ``pat-stacks`` which changes the overlay content and automatically get the form reinitialized.
 One idea would be to use a list of styled radio buttons with name ``tiptap-src`` and as value the URL of the image. This would then serve as a image selection widget.
-For an upload widget you can use a combination of ``pat-upload`` and ``pat-inject`` to upload a image and then return a form with a hidden ``tiptap-src`` input field with the value of the new image URL. If the form is then finally submitted via ``tiptap-confirm`` the image is set into the editor.
+For an upload widget you can use a combination of ``pat-upload`` and ``pat-inject`` to upload a image and then return a form with a hidden ``tiptap-src`` input field with the value of the new image URL.
+If the form is then finally submitted via ``tiptap-confirm`` the image is set into the editor.
 
 This is the related ``pat-tiptap`` config:
 
@@ -315,7 +323,7 @@ This is the DOM structure with the overlay:
           Caption:
           <textarea name="tiptap-caption"></textarea>
         </label>
-        <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+        <button class="close-panel" type="submit" name="tiptap-confirm">submit</button>
       </form>
     </div>
 
@@ -393,7 +401,7 @@ This is the DOM structure with the overlay:
           Source:
           <textarea name="tiptap-source"></textarea>
         </label>
-        <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+        <button class="close-panel" type="submit" name="tiptap-confirm">submit</button>
       </form>
     </div>
 

--- a/src/extensions/embed.js
+++ b/src/extensions/embed.js
@@ -120,6 +120,14 @@ function embed_panel({ app }) {
             };
 
             // FORM UPDATE
+            const form = dom.querySelectorAllAndMe(embed_panel, "form")?.[0];
+            if (form) {
+                events.add_event_listener(form, "submit", "tiptap_embed_submit", (e) => {
+                    // Prevent form submission when hitting "enter" within the form.
+                    // The form is handled by JS only.
+                    e.preventDefault();
+                });
+            }
             if (embed_confirm) {
                 // update on click on confirm
                 events.add_event_listener(

--- a/src/extensions/image-figure.js
+++ b/src/extensions/image-figure.js
@@ -146,6 +146,14 @@ function image_panel({ app }) {
             };
 
             // FORM UPDATE
+            const form = dom.querySelectorAllAndMe(image_panel, "form")?.[0];
+            if (form) {
+                events.add_event_listener(form, "submit", "tiptap_image_submit", (e) => {
+                    // Prevent form submission when hitting "enter" within the form.
+                    // The form is handled by JS only.
+                    e.preventDefault();
+                });
+            }
             if (image_confirm) {
                 // update on click on confirm
                 events.add_event_listener(

--- a/src/extensions/link.js
+++ b/src/extensions/link.js
@@ -166,6 +166,14 @@ function link_panel({ app }) {
             };
 
             // FORM UPDATE
+            const form = dom.querySelectorAllAndMe(link_panel, "form")?.[0];
+            if (form) {
+                events.add_event_listener(form, "submit", "tiptap_link_submit", (e) => {
+                    // Prevent form submission when hitting "enter" within the form.
+                    // The form is handled by JS only.
+                    e.preventDefault();
+                });
+            }
             if (link_confirm) {
                 // update on click on confirm
                 events.add_event_listener(

--- a/src/extensions/source.js
+++ b/src/extensions/source.js
@@ -35,6 +35,20 @@ function source_panel({ app }) {
                 cmd.run();
             };
 
+            // FORM UPDATE
+            const form = dom.querySelectorAllAndMe(source_panel, "form")?.[0];
+            if (form) {
+                events.add_event_listener(
+                    form,
+                    "submit",
+                    "tiptap_source_submit",
+                    (e) => {
+                        // Prevent form submission when hitting "enter" within the form.
+                        // The form is handled by JS only.
+                        e.preventDefault();
+                    }
+                );
+            }
             if (source_confirm) {
                 // update on click on confirm
                 events.add_event_listener(

--- a/src/index.html
+++ b/src/index.html
@@ -220,7 +220,7 @@
             Open in new window:
             <input type="checkbox" name="tiptap-target" value="_blank" />
           </label>
-          <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+          <button class="close-panel" type="submit" name="tiptap-confirm">submit</button>
           <button class="close-panel" type="button" name="tiptap-remove">remove link</button>
         </form>
     </template>
@@ -245,7 +245,7 @@
             <textarea name="tiptap-caption"></textarea>
           </label>
 
-          <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+          <button class="close-panel" type="submit" name="tiptap-confirm">submit</button>
         </form>
     </template>
 
@@ -265,7 +265,7 @@
             <textarea name="tiptap-caption"></textarea>
           </label>
 
-          <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+          <button class="close-panel" type="submit" name="tiptap-confirm">submit</button>
         </form>
     </template>
 
@@ -276,7 +276,7 @@
             Source:
             <textarea name="tiptap-source"></textarea>
           </label>
-          <button class="close-panel" type="button" name="tiptap-confirm">submit</button>
+          <button class="close-panel" type="submit" name="tiptap-confirm">submit</button>
         </form>
     </template>
 


### PR DESCRIPTION
Encourage in documentation to use .tiptap-confirm buttons in link, image, embed and source panels and actually prevent a form submit. This allows to hit <Enter> in forms and take over the changes without submitting to the server and without doing a full request/response cycle.

Fixes: https://github.com/Patternslib/pat-tiptap/issues/36