### PR TITLE
Table fixes

### DIFF
--- a/src/extensions/trailing-node.js
+++ b/src/extensions/trailing-node.js
@@ -1,0 +1,64 @@
+// TrailingNode extension from:
+//   https://gist.github.com/jelleroorda/2a3085f45ef75b9fdd9f76a4444d6bd6/0a2a7b51871bd01808f5663fcab9a4eb3d593559
+//   https://tiptap.dev/experiments/trailing-node
+//   https://github.com/ueberdosis/tiptap/issues/143
+
+import { Extension } from "@tiptap/core";
+import { PluginKey, Plugin } from "prosemirror-state";
+
+function nodeEqualsType({ types, node }) {
+    return (Array.isArray(types) && types.includes(node.type)) || node.type === types;
+}
+
+/**
+ * Extension based on:
+ * - https://github.com/ueberdosis/tiptap/blob/v1/packages/tiptap-extensions/src/extensions/TrailingNode.js
+ * - https://github.com/remirror/remirror/blob/e0f1bec4a1e8073ce8f5500d62193e52321155b9/packages/prosemirror-trailing-node/src/trailing-node-plugin.ts
+ */
+export const TrailingNode = Extension.create({
+    name: "trailingNode",
+
+    defaultOptions: {
+        node: "paragraph",
+        notAfter: ["paragraph"],
+    },
+
+    addProseMirrorPlugins() {
+        const plugin = new PluginKey(this.name);
+        const disabledNodes = Object.entries(this.editor.schema.nodes)
+            .map(([, value]) => value)
+            .filter((node) => this.options.notAfter.includes(node.name));
+
+        return [
+            new Plugin({
+                key: plugin,
+                appendTransaction: (_, __, state) => {
+                    const { doc, tr, schema } = state;
+                    const shouldInsertNodeAtEnd = plugin.getState(state);
+                    const endPosition = doc.content.size;
+                    const type = schema.nodes[this.options.node];
+
+                    if (!shouldInsertNodeAtEnd) {
+                        return;
+                    }
+
+                    return tr.insert(endPosition, type.create());
+                },
+                state: {
+                    init: (_, state) => {
+                        const lastNode = state.tr.doc.lastChild;
+                        return !nodeEqualsType({ node: lastNode, types: disabledNodes });
+                    },
+                    apply: (tr, value) => {
+                        if (!tr.docChanged) {
+                            return value;
+                        }
+
+                        const lastNode = tr.doc.lastChild;
+                        return !nodeEqualsType({ node: lastNode, types: disabledNodes });
+                    },
+                },
+            }),
+        ];
+    },
+});

--- a/src/extensions/trailing-node.js
+++ b/src/extensions/trailing-node.js
@@ -1,7 +1,20 @@
 // TrailingNode extension from:
-//   https://gist.github.com/jelleroorda/2a3085f45ef75b9fdd9f76a4444d6bd6/0a2a7b51871bd01808f5663fcab9a4eb3d593559
-//   https://tiptap.dev/experiments/trailing-node
-//   https://github.com/ueberdosis/tiptap/issues/143
+// https://gist.github.com/jelleroorda/2a3085f45ef75b9fdd9f76a4444d6bd6/0a2a7b51871bd01808f5663fcab9a4eb3d593559
+// https://tiptap.dev/experiments/trailing-node
+// https://github.com/ueberdosis/tiptap/issues/143
+//
+//   The trailing node extension is necessary to pragmatically fix a problem
+//   with tables and table selections. When the last node in the document is a
+//   table and the last table cell is empty, then pressing <CTRL>-<a> to select
+//   everyting only selects the very first node in the document. As soon as one
+//   of the conditions - table not the last node or last table cell not empty -
+//   is not met, <CTRL>-<a> selects all, as expected.
+//   The Problem exists throughout browsers.
+//
+//   More information here:
+//   - https://github.com/ueberdosis/tiptap/issues/2401
+//   - https://github.com/ueberdosis/tiptap/issues/3651
+//
 
 import { Extension } from "@tiptap/core";
 import { PluginKey, Plugin } from "prosemirror-state";
@@ -10,55 +23,63 @@ function nodeEqualsType({ types, node }) {
     return (Array.isArray(types) && types.includes(node.type)) || node.type === types;
 }
 
-/**
- * Extension based on:
- * - https://github.com/ueberdosis/tiptap/blob/v1/packages/tiptap-extensions/src/extensions/TrailingNode.js
- * - https://github.com/remirror/remirror/blob/e0f1bec4a1e8073ce8f5500d62193e52321155b9/packages/prosemirror-trailing-node/src/trailing-node-plugin.ts
- */
-export const TrailingNode = Extension.create({
-    name: "trailingNode",
+export const factory = () => {
+    /**
+     * Extension based on:
+     * - https://github.com/ueberdosis/tiptap/blob/v1/packages/tiptap-extensions/src/extensions/TrailingNode.js
+     * - https://github.com/remirror/remirror/blob/e0f1bec4a1e8073ce8f5500d62193e52321155b9/packages/prosemirror-trailing-node/src/trailing-node-plugin.ts
+     */
+    return Extension.create({
+        name: "trailingNode",
 
-    defaultOptions: {
-        node: "paragraph",
-        notAfter: ["paragraph"],
-    },
+        defaultOptions: {
+            node: "paragraph",
+            notAfter: ["paragraph"],
+        },
 
-    addProseMirrorPlugins() {
-        const plugin = new PluginKey(this.name);
-        const disabledNodes = Object.entries(this.editor.schema.nodes)
-            .map(([, value]) => value)
-            .filter((node) => this.options.notAfter.includes(node.name));
+        addProseMirrorPlugins() {
+            const plugin = new PluginKey(this.name);
+            const disabledNodes = Object.entries(this.editor.schema.nodes)
+                .map(([, value]) => value)
+                .filter((node) => this.options.notAfter.includes(node.name));
 
-        return [
-            new Plugin({
-                key: plugin,
-                appendTransaction: (_, __, state) => {
-                    const { doc, tr, schema } = state;
-                    const shouldInsertNodeAtEnd = plugin.getState(state);
-                    const endPosition = doc.content.size;
-                    const type = schema.nodes[this.options.node];
+            return [
+                new Plugin({
+                    key: plugin,
+                    appendTransaction: (_, __, state) => {
+                        const { doc, tr, schema } = state;
+                        const shouldInsertNodeAtEnd = plugin.getState(state);
+                        const endPosition = doc.content.size;
+                        const type = schema.nodes[this.options.node];
 
-                    if (!shouldInsertNodeAtEnd) {
-                        return;
-                    }
-
-                    return tr.insert(endPosition, type.create());
-                },
-                state: {
-                    init: (_, state) => {
-                        const lastNode = state.tr.doc.lastChild;
-                        return !nodeEqualsType({ node: lastNode, types: disabledNodes });
-                    },
-                    apply: (tr, value) => {
-                        if (!tr.docChanged) {
-                            return value;
+                        if (!shouldInsertNodeAtEnd) {
+                            return;
                         }
 
-                        const lastNode = tr.doc.lastChild;
-                        return !nodeEqualsType({ node: lastNode, types: disabledNodes });
+                        return tr.insert(endPosition, type.create());
                     },
-                },
-            }),
-        ];
-    },
-});
+                    state: {
+                        init: (_, state) => {
+                            const lastNode = state.tr.doc.lastChild;
+                            return !nodeEqualsType({
+                                node: lastNode,
+                                types: disabledNodes,
+                            });
+                        },
+                        apply: (tr, value) => {
+                            if (!tr.docChanged) {
+                                return value;
+                            }
+
+                            const lastNode = tr.doc.lastChild;
+                            return !nodeEqualsType({
+                                node: lastNode,
+                                types: disabledNodes,
+                            });
+                        },
+                    },
+                }),
+            ];
+        },
+    });
+};

--- a/src/index.html
+++ b/src/index.html
@@ -202,7 +202,45 @@
             <figcaption>hello</figcaption>
           </figure>
 
-          <p>A new paragraph.</p>
+          <p>A new paragraph with a table.</p>
+
+          <table>
+            <tbody>
+              <tr>
+                <th>
+                  <p>column 1</p>
+                </th>
+                <th>
+                  <p>column 2</p>
+                </th>
+                <th>
+                  <p>column 3</p>
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  <p>cell 1.1</p>
+                </td>
+                <td>
+                  <p>cell 1.2</p>
+                </td>
+                <td>
+                  <p>cell 1.3</p>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <p>cell 2.1</p>
+                </td>
+                <td>
+                  <p>next cell is intentionally left blank</p>
+                </td>
+                <td>
+                  <p></p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
       </textarea>
 
     </section>

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -146,6 +146,8 @@ export async function init_extensions({ app }) {
         extensions.push((await import("@tiptap/extension-table-cell")).default);
         extensions.push((await import("@tiptap/extension-table-header")).default);
         extensions.push((await import("@tiptap/extension-table-row")).default);
+        // For the reason to include the next extension see the trailing-node extension code.
+        extensions.push((await import("./extensions/trailing-node")).factory());
         has_tables = true;
     }
 

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -140,7 +140,7 @@ export async function init_extensions({ app }) {
     ) {
         extensions.push(
             (await import("@tiptap/extension-table")).default.configure({
-                resizable: true,
+                resizable: false,
             })
         );
         extensions.push((await import("@tiptap/extension-table-cell")).default);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = () => {
 
     if (process.env.NODE_ENV === "development") {
         config.devServer.static.directory = __dirname;
+        config.devServer.port = "3002";
     }
 
     return config;


### PR DESCRIPTION
This PR contains these fixes:

## fix: Fix problem with table not selectable with ctrl-a

There is a strange problem with tables and selecting all content with ctrl-a. When the last node in the document is a table and the last table cell is empty, then pressing CTRL-a to select everyting only selects the very first node in the document. As soon as one of the conditions - table not the last node or last table cell not empty - is not met, CTRL-a selects all, as expected.

We fix the problem by making sure some content is following the table and add an empty paragraph. When another solution is found we can remove this hack again.

More information here:

  - https://github.com/ueberdosis/tiptap/issues/2401
  - https://github.com/ueberdosis/tiptap/issues/3651

## maint: Disable horizontal table cell resizing.

We would need quite some extra CSS for the `.column-resize-handle` for a questionable benefit. Disable it for now until we need it back and find a solution for the missing CSS.

Example for the CSS to be added (touches also table and cell styles):
https://tiptap.dev/api/nodes/table#usage

## maint: Use a different webpack dev server port than the default Patternslib one.