### PR TITLE
fix: Allow to select-all in tables.

### DIFF
--- a/src/extensions/fixed-paragraph.js
+++ b/src/extensions/fixed-paragraph.js
@@ -1,0 +1,65 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import { Plugin } from "prosemirror-state";
+
+export const factory = () => {
+    return Node.create({
+        name: "fixed-paragraph",
+
+        addOptions() {
+            return {
+                HTMLAttributes: {
+                    class: "fixed-paragraph",
+                },
+            };
+        },
+
+        group: "block",
+        isolating: true,
+        selectable: false,
+
+        parseHTML() {
+            return [
+                {
+                    tag: "p",
+                    getAttrs: (node) => node.matches(".fixed-paragraph") && null,
+                },
+            ];
+        },
+
+        renderHTML({ HTMLAttributes }) {
+            return [
+                "p",
+                mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+                " ", // Add a space to the end of the paragraph to make it selectable
+            ];
+        },
+
+        addProseMirrorPlugins() {
+            return [
+                new Plugin({
+                    filterTransaction(transaction, state) {
+                        let result = true; // true for keep, false for stop transaction
+                        const replaceSteps = [];
+                        transaction.steps.forEach((step, index) => {
+                            if (step.jsonID === "replace") {
+                                replaceSteps.push(index);
+                            }
+                        });
+
+                        replaceSteps.forEach((index) => {
+                            const map = transaction.mapping.maps[index];
+                            const oldStart = map.ranges[0];
+                            const oldEnd = map.ranges[0] + map.ranges[1];
+                            state.doc.nodesBetween(oldStart, oldEnd, (node) => {
+                                if (node.type.name === "fixed-paragraph") {
+                                    result = false;
+                                }
+                            });
+                        });
+                        return result;
+                    },
+                }),
+            ];
+        },
+    });
+};

--- a/src/extensions/trailing-node.js
+++ b/src/extensions/trailing-node.js
@@ -33,8 +33,8 @@ export const factory = () => {
         name: "trailingNode",
 
         defaultOptions: {
-            node: "paragraph",
-            notAfter: ["paragraph"],
+            node: "fixed-paragraph",
+            notAfter: ["paragraph", "fixed-paragraph"],
         },
 
         addProseMirrorPlugins() {
@@ -56,7 +56,10 @@ export const factory = () => {
                             return;
                         }
 
-                        return tr.insert(endPosition, type.create());
+                        return tr.insert(
+                            endPosition,
+                            type.create(null, [schema.text(" ")])
+                        );
                     },
                     state: {
                         init: (_, state) => {

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -147,6 +147,7 @@ export async function init_extensions({ app }) {
         extensions.push((await import("@tiptap/extension-table-header")).default);
         extensions.push((await import("@tiptap/extension-table-row")).default);
         // For the reason to include the next extension see the trailing-node extension code.
+        extensions.push((await import("./extensions/fixed-paragraph")).factory());
         extensions.push((await import("./extensions/trailing-node")).factory());
         has_tables = true;
     }


### PR DESCRIPTION
Allow to select all (Ctrl-A, Command-A) with tables in certain conditions.
Due to a tiptap/ProseMirror bug tables with some empty cells and no content preceding or following the table, selecting the whole table did not work. This fix makes sure that a non-empty paragraph is added at the end, if no other content is present at the end of the document.

Follow-up from:
- https://github.com/Patternslib/pat-tiptap/pull/61

More information here:
- https://github.com/ueberdosis/tiptap/issues/2401
- https://github.com/ueberdosis/tiptap/issues/3651