### PR TITLE
feat: Support configuration of extra link protocols.

### DIFF
--- a/src/documentation.md
+++ b/src/documentation.md
@@ -552,5 +552,5 @@ This is an CSS example to show the placeholder on any empty paragraph:
 | link-menu              | String | URL or CSS selector pointing to the link context menu contents.                    |
 | mentions-menu          | String | URL or CSS selector pointing to the mentions context menu contents.                |
 | tags-menu              | String | URL or CSS selector pointing to the tags context menu contents.                    |
-
+| link-extra-protocols   | Array  | Array of extra protocols which are allowed to be used in the <a> `href` attribute. |
 

--- a/src/tiptap.js
+++ b/src/tiptap.js
@@ -25,6 +25,8 @@ parser.addArgument("link-menu", null);
 parser.addArgument("mentions-menu", null);
 parser.addArgument("tags-menu", null);
 
+parser.addArgument("link-extra-protocols", [], undefined, true);
+
 // TODO: Remove with next major version.
 // BBB - Compatibility aliases
 parser.addAlias("context-menu-link", "link-menu");

--- a/src/tiptap.test.js
+++ b/src/tiptap.test.js
@@ -395,7 +395,8 @@ describe("pat-tiptap", () => {
                   class="pat-tiptap"
                   data-pat-tiptap="
                     toolbar-external: #tiptap-external-toolbar;
-                    link-panel: #link-panel
+                    link-panel: #link-panel;
+                    link-extra-protocols: fantasy;
                   ">
               </textarea>
               <template id="modal-link">
@@ -492,6 +493,18 @@ describe("pat-tiptap", () => {
             const anchor = document.querySelector(".tiptap-container a");
             expect(anchor.href).toBe("callto:0123456789");
             expect(anchor.textContent).toBe("Callto text");
+        });
+
+        it("5.7 - Supports obscure protocols, when configured.", async () => {
+            document.querySelector("#link-panel [name=tiptap-href]").value = "fantasy://patternslib.com"; // prettier-ignore
+            document.querySelector("#link-panel [name=tiptap-text]").value = "Link text"; // prettier-ignore
+            document.querySelector("#link-panel [name=tiptap-confirm]").dispatchEvent(new Event("click")); // prettier-ignore
+            await utils.timeout(1);
+
+            const anchor = document.querySelector(".tiptap-container a");
+            expect(anchor).toBeTruthy();
+            expect(anchor.href).toBe("fantasy://patternslib.com");
+            expect(anchor.textContent).toBe("Link text");
         });
     });
 

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -164,6 +164,7 @@ export async function init_extensions({ app }) {
                 HTMLAttributes: { target: null, rel: null }, // don't set these attributes.
                 openOnClick: false, // don't open documents while editing.
                 linkOnPaste: true,
+                protocols: app.options.link["extra-protocols"],
             })
         );
     }


### PR DESCRIPTION
This fixes a problem where Lotus Notes URLs were stripped out. These URLs have a notes:// protocol.
There is now a new configuration option "link-extra-protocols" to add new ones along well-known like https, ftp, mail, etc.